### PR TITLE
Don't shadow user defined PDBs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.x
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/controller_test.go
+++ b/controller_test.go
@@ -194,7 +194,7 @@ func TestAddPDBs(t *testing.T) {
 	}
 }
 
-func TestGetPDB(t *testing.T) {
+func TestGetPDBs(t *testing.T) {
 	labels := map[string]string{"k": "v"}
 	pdbs := []pv1beta1.PodDisruptionBudget{
 		{
@@ -209,18 +209,18 @@ func TestGetPDB(t *testing.T) {
 		},
 	}
 
-	pdb := getPDB(labels, pdbs, nil)
-	if pdb == nil {
+	matchedPDBs := getPDBs(labels, pdbs, nil)
+	if len(matchedPDBs) == 0 {
 		t.Errorf("expected to get matching PDB")
 	}
 
-	pdb = getPDB(labels, pdbs, labels)
-	if pdb == nil {
+	matchedPDBs = getPDBs(labels, pdbs, labels)
+	if len(matchedPDBs) == 0 {
 		t.Errorf("expected to get matching PDB")
 	}
 
-	pdb = getPDB(nil, pdbs, labels)
-	if pdb != nil {
+	matchedPDBs = getPDBs(nil, pdbs, labels)
+	if len(matchedPDBs) != 0 {
 		t.Errorf("did not expect to find matching PDB")
 	}
 }
@@ -245,4 +245,54 @@ func TestContainLabels(t *testing.T) {
 	if containLabels(labels, notExpected) {
 		t.Errorf("did not expect %s to be contained in %s", notExpected, labels)
 	}
+}
+
+func TestLabelsIntersect(tt *testing.T) {
+	for _, tc := range []struct {
+		msg       string
+		a         map[string]string
+		b         map[string]string
+		intersect bool
+	}{
+		{
+			msg: "matching maps should intersect",
+			a: map[string]string{
+				"foo": "bar",
+			},
+			b: map[string]string{
+				"foo": "bar",
+			},
+			intersect: true,
+		},
+		{
+			msg: "partly matching maps should intersect",
+			a: map[string]string{
+				"foo": "bar",
+			},
+			b: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+			},
+			intersect: true,
+		},
+		{
+			msg: "maps with matching keys but different values should not inersect",
+			a: map[string]string{
+				"foo": "bar",
+				"bar": "baz",
+			},
+			b: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+			},
+			intersect: false,
+		},
+	} {
+		tt.Run(tc.msg, func(t *testing.T) {
+			if labelsIntersect(tc.a, tc.b) != tc.intersect {
+				t.Errorf("expected intersection to be %t, was %t", tc.intersect, labelsIntersect(tc.a, tc.b))
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Since Kubernetes can only handle one PDB per resource it's a problem if the PDB controller creates a PDB for a statefulset or a deployment and there is a slightly different PDB for the same statefulset or deployment defined by the users.

This changes the way PDBs are matched against statefulsets and deployment labels to detect if there are already existing PDBs covering a statefulset or deployment.

Before it was checking if the matchLabels of a PDB was contained in the template.Labels of a statefulset or deployment. This can be a problem if there is a user defined PDB e.g. with the following matchLabels:

```yaml
matchLabels:
  application: foo
  master: true
  version: x
```

And a deployment with the labels:

```yaml
labels:
  application: foo
  version: x
```
In this case the controller wouldn't have found the PDB because of the extra `master: true` label.

This problem is fixed by checking if the labels/matchLabels just intersect. Intersection means if at least one key/value pair exists in both label maps AND there are no labels where the key matches but the value doesn't. E.g. we don't want to match if the labels are defined like this:

```yaml
matchLabels:
  application: foo
  version: x
```

```yaml
labels:
  application: bar
  version: x
```