### PR TITLE
Add option to remove PDBs for non-ready resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ replicas of the related resource is scaled to 1 or less. This
 is done to prevent deadlocking for clients depending on the PDBs e.g. cluster
 upgrade tools.
 
+Additionally you can run the controller with the flag `--non-ready-ttl=15m`
+which means it will remove owned PDBs in case the pods of a targeted deployment
+or statefulset are non-ready for more than the specified ttl. This is another
+way to ensure broken deployments doesn't block cluster operations.
+
 ## Building
 
 To build this project you need to have [Go](https://golang.org/dl/) installed

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 const (
 	defaultInterval      = "1m"
 	defaultPDBNameSuffix = "pdb-controller"
+	defaultNonReadyTTL   = "0s"
 )
 
 type config struct {
@@ -24,6 +25,7 @@ type config struct {
 	APIServer     *url.URL
 	Debug         bool
 	PDBNameSuffix string
+	NonReadyTTL   time.Duration
 }
 
 func main() {
@@ -32,6 +34,7 @@ func main() {
 	kingpin.Flag("apiserver", "API server url.").URLVar(&config.APIServer)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&config.Debug)
 	kingpin.Flag("pdb-name-suffix", "Specify default PDB name suffix.").Default(defaultPDBNameSuffix).StringVar(&config.PDBNameSuffix)
+	kingpin.Flag("non-ready-ttl", "Set the ttl for when to remove the managed PDB if the deployment/statefulset is unhealthy (default: disabled).").Default(defaultNonReadyTTL).DurationVar(&config.NonReadyTTL)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -57,7 +60,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	controller, err := NewPDBController(config.Interval, client, config.PDBNameSuffix)
+	controller, err := NewPDBController(config.Interval, client, config.PDBNameSuffix, config.NonReadyTTL)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This adds a flag `--non-ready-ttl` which, when set, will make the
controller remove managed PDBs in case the pods of a targeted
deployment/statefulset are not ready for ttl time.

Enabling this feature ensures that broken deployments won't block
cluster operations.

Fix #13