### PR TITLE
Explicitly target a deployment or a statefulset

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/apps/v1beta1"
 	pv1beta1 "k8s.io/client-go/pkg/apis/policy/v1beta1"
 )


### PR DESCRIPTION
The most common source of invalid PDBs is the users creating a deployment or a statefulset and a cronjob with the same application and then simply using an application=foo selector. We can add a quick workaround that will explicitly target pods belonging to a deployment or a statefulset to avoid this situation.

**TODO**: tests.