### PR TITLE
Fixing regression after dependency update

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	pv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -223,7 +223,7 @@ func (n *PDBController) addPDBs(namespace *v1.Namespace) error {
 		}
 
 		switch r := resource.(type) {
-		case v1beta1.Deployment:
+		case appsv1.Deployment:
 			if r.Labels == nil {
 				r.Labels = make(map[string]string)
 			}
@@ -241,7 +241,7 @@ func (n *PDBController) addPDBs(namespace *v1.Namespace) error {
 			}
 			pdb.Labels = labels
 			pdb.Spec.Selector = r.Spec.Selector
-		case v1beta1.StatefulSet:
+		case appsv1.StatefulSet:
 			if r.Labels == nil {
 				r.Labels = make(map[string]string)
 			}


### PR DESCRIPTION
Not sure if it was done intentionally or not,  but the current code does not work with apps/v1 Deployments and StatefulSets, producing the following output:
```
an empty namespace may not be set during creation
```
Debugging shows the obvious thing - Deployment/StatefulSet params like Name and Namespace are empty when using v1beta1 machinery against v1 objects.

I assume that by doing dependency update it was not supposed to have backward compatibility with apps/v1beta1, so my change just finishes the dependencies update and fixes the issue described above.