### PR TITLE
Fix ownership handling + update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.1

--- a/resources.go
+++ b/resources.go
@@ -1,16 +1,41 @@
 package main
 
-import appsv1 "k8s.io/api/apps/v1"
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 type kubeResource interface {
+	APIVersion() string
+	Kind() string
+	Name() string
+	UID() types.UID
 	Annotations() map[string]string
 	TemplateLabels() map[string]string
 	Replicas() int32
 	StatusReadyReplicas() int32
+	Selector() *metav1.LabelSelector
 }
 
 type statefulSet struct {
 	appsv1.StatefulSet
+}
+
+func (s statefulSet) APIVersion() string {
+	return s.StatefulSet.APIVersion
+}
+
+func (s statefulSet) Kind() string {
+	return s.StatefulSet.Kind
+}
+
+func (s statefulSet) Name() string {
+	return s.StatefulSet.Name
+}
+
+func (s statefulSet) UID() types.UID {
+	return s.StatefulSet.UID
 }
 
 func (s statefulSet) Annotations() map[string]string {
@@ -32,8 +57,28 @@ func (s statefulSet) StatusReadyReplicas() int32 {
 	return s.StatefulSet.Status.ReadyReplicas
 }
 
+func (s statefulSet) Selector() *metav1.LabelSelector {
+	return s.StatefulSet.Spec.Selector
+}
+
 type deployment struct {
 	appsv1.Deployment
+}
+
+func (d deployment) APIVersion() string {
+	return d.Deployment.APIVersion
+}
+
+func (d deployment) Kind() string {
+	return d.Deployment.Kind
+}
+
+func (d deployment) Name() string {
+	return d.Deployment.Name
+}
+
+func (d deployment) UID() types.UID {
+	return d.Deployment.UID
 }
 
 func (d deployment) Annotations() map[string]string {
@@ -53,4 +98,8 @@ func (d deployment) Replicas() int32 {
 
 func (d deployment) StatusReadyReplicas() int32 {
 	return d.Deployment.Status.ReadyReplicas
+}
+
+func (d deployment) Selector() *metav1.LabelSelector {
+	return d.Deployment.Spec.Selector
 }


### PR DESCRIPTION
This fixes two bugs in the controller

1. Correctly check for ownership not based on labels but based on `ownerReferences`. Without this you can risk that the deployment (owner) changes matchLabels in a way where it will no longer match the pdb and therefore not be considered an owner.
2. Update PDB selector to match that of the owner resource, otherwise PDBs can get out of sync with the Deployment/Statefulset.