### PR TITLE
Fix owner handling and update PDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/google/go-cmp v0.3.0
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.1

--- a/main.go
+++ b/main.go
@@ -60,10 +60,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	controller, err := NewPDBController(config.Interval, client, config.PDBNameSuffix, config.NonReadyTTL)
-	if err != nil {
-		log.Fatal(err)
-	}
+	controller := NewPDBController(config.Interval, client, config.PDBNameSuffix, config.NonReadyTTL)
 
 	stopChan := make(chan struct{}, 1)
 	go handleSigterm(stopChan)

--- a/resources.go
+++ b/resources.go
@@ -10,8 +10,10 @@ type kubeResource interface {
 	APIVersion() string
 	Kind() string
 	Name() string
+	Namespace() string
 	UID() types.UID
 	Annotations() map[string]string
+	Labels() map[string]string
 	TemplateLabels() map[string]string
 	Replicas() int32
 	StatusReadyReplicas() int32
@@ -34,12 +36,20 @@ func (s statefulSet) Name() string {
 	return s.StatefulSet.Name
 }
 
+func (s statefulSet) Namespace() string {
+	return s.StatefulSet.Namespace
+}
+
 func (s statefulSet) UID() types.UID {
 	return s.StatefulSet.UID
 }
 
 func (s statefulSet) Annotations() map[string]string {
 	return s.StatefulSet.Annotations
+}
+
+func (s statefulSet) Labels() map[string]string {
+	return s.StatefulSet.Labels
 }
 
 func (s statefulSet) TemplateLabels() map[string]string {
@@ -77,12 +87,20 @@ func (d deployment) Name() string {
 	return d.Deployment.Name
 }
 
+func (d deployment) Namespace() string {
+	return d.Deployment.Namespace
+}
+
 func (d deployment) UID() types.UID {
 	return d.Deployment.UID
 }
 
 func (d deployment) Annotations() map[string]string {
 	return d.Deployment.Annotations
+}
+
+func (d deployment) Labels() map[string]string {
+	return d.Deployment.Labels
 }
 
 func (d deployment) TemplateLabels() map[string]string {


### PR DESCRIPTION
#34 fixed some issues with owner handling but unfortunately introduced others :(

This PR improves the tests to cover what I previously missed and fixes the issue

* Update PDB when something changes (not only when TTL needs to be updated)
* Lookup owned PDBs based on `ownerReferences` AND `heritage=pdb-controller` labels.
  * Lookup owned PDBs, not based on matchedPDBs but based on ALL PDBs. Without this we won't find the no longer matching, but still owned PDBs.
* Fix tests which were previously not working because we changed how to detect "readiness" (replicas == readyReplicas).