### PR TITLE
Add permissions to read pods

### DIFF
--- a/docs/rbac.yaml
+++ b/docs/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
   name: pdb-controller
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["namespaces", "pods"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets"]


### PR DESCRIPTION
The controller needs to read pods, add permissions.

Fix #39 