### PR TITLE
Fix multi-arch image push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
         make test
         make
         make build.docker
-        make build.docker.multiarch
     - run: goveralls -coverprofile=profile.cov -service=github
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build.docker: build.linux
 
 build.docker.multiarch: build.linux.amd64 build.linux.arm64
 	docker buildx create --use
-	docker buildx build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --platform linux/amd64,linux/arm64 .
+	docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --platform linux/amd64,linux/arm64 --push .
 
 
 build.push: build.docker


### PR DESCRIPTION
This patch removes the `docker.build.multiarch` Make target from the action CI and reintroduces the `--push` flag for downstream pipeline to be able to publish the multi-arch image.