### PR TITLE
Patch buildx command with config for cdp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build.docker: build.linux
 	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --build-arg TARGETARCH= .
 
 build.docker.multiarch: build.linux.amd64 build.linux.arm64
-	docker buildx create --use
+	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
 	docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --platform linux/amd64,linux/arm64 --push .
 
 

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,5 @@ build/osx/$(BINARY): $(SOURCES)
 build.docker: build.linux
 	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --build-arg TARGETARCH= .
 
-build.docker.multiarch: build.linux.amd64 build.linux.arm64
-	docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
-	docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3.13:latest -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE) --platform linux/amd64,linux/arm64 --push .
-
-
 build.push: build.docker
 	docker push "$(IMAGE):$(TAG)"


### PR DESCRIPTION
Fixing the `buildx create` command to provide the configuration needed to successfully build in CDP.