### PR TITLE
Update alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3.17:latest
+ARG BASE_IMAGE=alpine:3.20
 FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 


### PR DESCRIPTION
Current Alpine 3.17 image has vulnerabilities and should be updated.
Also I have not found the source code for it, and proposed to use vanilla Alpine image instead.