### PR TITLE
Only do docker related build steps on master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,15 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up QEMU for multi-arch
+      if: github.ref == 'refs/heads/master'
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
+      if: github.ref == 'refs/heads/master'
       uses: docker/setup-buildx-action@v2
 
     - name: Log in to DockerHub
+      if: github.ref == 'refs/heads/master'
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Only do docker related build steps if building `master`. This is to avoid failing the build e.g. on dependabot PRs.