### PR TITLE
Allow updating indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     all-go-mod-patch-and-minor:
       patterns: ["*"]
       update-types: ["patch", "minor"]
+  allow:
+  # Allow updates for indirect dependencies
+  - dependency-type: "all"
   ignore:
   # Ignore k8s and its transitives modules as they are upgraded manually
   - dependency-name: "k8s.io/*"


### PR DESCRIPTION
Allow dependabot to update indirect dependencies such that vulnerable indirect dependencies can be automatically updated.