### PR TITLE
initialize environment when we're going to build+push a tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,15 +23,15 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up QEMU for multi-arch
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to DockerHub
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
These steps a re being skipped when building from a tag. That's why master works but tags don't.

Failing pipeline: https://github.com/mikkeloscar/pdb-controller/actions/runs/17908793694/job/50915296468