### PR TITLE
Add opt-in PodDisruptionBudget support for Argo Rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ way to ensure broken deployments doesn't block cluster operations.
 This global value can also be overriden by specifying the annotation
 `pdb-controller.zalando.org/non-ready-ttl` on a deployment or statefulset.
 
+## Argo Rollouts
+
+Passing `--enable-rollouts` makes the controller also manage default PDBs for
+[Argo Rollouts][argo-rollouts] (`argoproj.io/v1alpha1`), treating them exactly
+like Deployments/StatefulSets (same replica and selector rules).
+
+It is **opt-in and safe**: when the flag is unset the controller behaves
+exactly as before and makes no extra API calls. When it is set but the Rollout
+CRD isn't installed — or the RBAC in [docs/rbac.yaml](docs/rbac.yaml) hasn't
+been extended with `rollouts.argoproj.io` — Rollouts are simply skipped and
+Deployment/StatefulSet handling is never affected. The CRD is re-checked every
+loop, so installing Argo Rollouts later is picked up without a restart.
+
+[argo-rollouts]: https://argoproj.github.io/rollouts/
+
 ## Building
 
 This project uses [Go modules](https://github.com/golang/go/wiki/Modules) as

--- a/controller.go
+++ b/controller.go
@@ -10,8 +10,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	pv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 )
@@ -28,10 +31,11 @@ var (
 	ownerLabels = map[string]string{heritageLabel: pdbController}
 )
 
-// PDBController creates PodDisruptionBudgets for deployments and StatefulSets
-// if missing.
+// PDBController creates PodDisruptionBudgets for Deployments, StatefulSets and
+// (when the CRD is installed) Argo Rollouts if missing.
 type PDBController struct {
 	kubernetes.Interface
+	dynamicClient      dynamic.Interface
 	interval           time.Duration
 	pdbNameSuffix      string
 	nonReadyTTL        time.Duration
@@ -40,9 +44,13 @@ type PDBController struct {
 }
 
 // NewPDBController initializes a new PDBController.
-func NewPDBController(interval time.Duration, client kubernetes.Interface, pdbNameSuffix string, nonReadyTTL time.Duration, parentResourceHash bool, maxUnavailable intstr.IntOrString) *PDBController {
+//
+// dynamicClient is used to discover Argo Rollouts. It may be nil, in which case
+// Rollouts are skipped entirely.
+func NewPDBController(interval time.Duration, client kubernetes.Interface, dynamicClient dynamic.Interface, pdbNameSuffix string, nonReadyTTL time.Duration, parentResourceHash bool, maxUnavailable intstr.IntOrString) *PDBController {
 	return &PDBController{
 		Interface:          client,
+		dynamicClient:      dynamicClient,
 		interval:           interval,
 		pdbNameSuffix:      pdbNameSuffix,
 		nonReadyTTL:        nonReadyTTL,
@@ -89,7 +97,12 @@ func (n *PDBController) runOnce(ctx context.Context) error {
 		return err
 	}
 
-	resources := make([]kubeResource, 0, len(deployments.Items)+len(statefulSets.Items))
+	// Argo Rollouts is opt-in and optional; this is empty (never errors) when
+	// support is disabled or the CRD isn't installed. It deliberately cannot
+	// break the Deployment/StatefulSet handling above.
+	rollouts := n.listRollouts(ctx)
+
+	resources := make([]kubeResource, 0, len(deployments.Items)+len(statefulSets.Items)+len(rollouts))
 
 	for _, d := range deployments.Items {
 		// manually set Kind and APIVersion because of a bug in
@@ -109,9 +122,60 @@ func (n *PDBController) runOnce(ctx context.Context) error {
 		resources = append(resources, statefulSet{s})
 	}
 
+	resources = append(resources, rollouts...)
+
 	desiredPDBs := n.generateDesiredPDBs(resources, managedPDBs, unmanagedPDBs)
 	n.reconcilePDBs(ctx, desiredPDBs, managedPDBs)
 	return nil
+}
+
+// listRollouts returns all Argo Rollouts as kubeResources. Argo Rollouts support
+// is opt-in (--enable-rollouts); when disabled the dynamic client is nil and this
+// is a no-op. It NEVER returns an error: rollout discovery must not be able to
+// break the existing Deployment/StatefulSet reconciliation, so every failure mode
+// is logged and treated as "no rollouts this round":
+//
+//   - CRD not installed (the API server 404s the resource → NotFound): expected,
+//     debug-logged.
+//   - RBAC not granted (Forbidden): e.g. enabled without updating the ClusterRole;
+//     warn so it's visible, but keep going.
+//   - anything else (transient API errors): error-logged, retried next loop.
+//
+// The CRD is re-checked every loop, so installing Argo Rollouts (or fixing RBAC)
+// later is picked up without a restart.
+func (n *PDBController) listRollouts(ctx context.Context) []kubeResource {
+	if n.dynamicClient == nil {
+		return nil
+	}
+
+	list, err := n.dynamicClient.Resource(rolloutGVR).Namespace(v1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
+			log.Debug("Argo Rollouts CRD not installed; skipping Rollouts")
+		case apierrors.IsForbidden(err):
+			log.Warnf("Not permitted to list Rollouts; skipping (add rollouts.argoproj.io to the ClusterRole to enable): %v", err)
+		default:
+			log.Errorf("Failed to list Rollouts; skipping this round: %v", err)
+		}
+		return nil
+	}
+
+	resources := make([]kubeResource, 0, len(list.Items))
+	for i := range list.Items {
+		var r argoRollout
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.Items[i].Object, &r); err != nil {
+			log.Errorf("Failed to decode Rollout; skipping it: %v", err)
+			continue
+		}
+		// Kind/APIVersion are needed for the PDB's ownerReference; set them
+		// explicitly rather than trusting the list payload.
+		r.Kind = "Rollout"
+		r.APIVersion = rolloutGVR.GroupVersion().String()
+		resources = append(resources, rollout{r})
+	}
+
+	return resources
 }
 
 func (n *PDBController) generateDesiredPDBs(resources []kubeResource, managedPDBs, unmanagedPDBs map[string]pv1.PodDisruptionBudget) map[string]pv1.PodDisruptionBudget {

--- a/controller_test.go
+++ b/controller_test.go
@@ -498,6 +498,7 @@ func TestController(tt *testing.T) {
 				controller := NewPDBController(
 					0,
 					setupMockKubernetes(t, pdbs, deployments, statefulSets, namespaces),
+					nil, // dynamic client: Argo Rollout support off for these cases
 					"pdb-controller",
 					time.Hour,
 					parentResourceHash,

--- a/docs/rbac.yaml
+++ b/docs/rbac.yaml
@@ -15,6 +15,11 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "statefulsets"]
   verbs: ["get", "list"]
+# Only required when running with --enable-rollouts (Argo Rollouts support).
+# Harmless to grant when the CRD isn't installed.
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get", "list"]
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "list", "create", "delete", "update"]

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -31,6 +32,7 @@ type config struct {
 	NonReadyTTL        time.Duration
 	ParentResourceHash bool
 	MaxUnavailable     string
+	EnableRollouts     bool
 }
 
 func main() {
@@ -42,6 +44,7 @@ func main() {
 	kingpin.Flag("non-ready-ttl", "Set the ttl for when to remove the managed PDB if the deployment/statefulset is unhealthy (default: disabled).").Default(defaultNonReadyTTL).DurationVar(&config.NonReadyTTL)
 	kingpin.Flag("use-parent-resource-hash", "Uses parent-resource-hash labels as selector for PDBs.").BoolVar(&config.ParentResourceHash)
 	kingpin.Flag("max-unavailable", "The value of maxUnavailable that would be set in the generated PDBs.").Default(defaultMaxUnavailable).StringVar(&config.MaxUnavailable)
+	kingpin.Flag("enable-rollouts", "Also manage PDBs for Argo Rollouts (argoproj.io/v1alpha1). Opt-in; requires the Rollout CRD and get/list/watch RBAC on rollouts.argoproj.io.").BoolVar(&config.EnableRollouts)
 	kingpin.Parse()
 
 	if config.Debug {
@@ -67,9 +70,23 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Argo Rollout support is opt-in. When disabled, the dynamic client stays
+	// nil and the controller behaves exactly as before — no extra API calls,
+	// no extra RBAC. Creation failure is non-fatal: degrade to Rollouts-off
+	// rather than break Deployment/StatefulSet handling.
+	var dynamicClient dynamic.Interface
+	if config.EnableRollouts {
+		dynamicClient, err = dynamic.NewForConfig(kubeConfig)
+		if err != nil {
+			log.Warnf("Failed to create dynamic client; Argo Rollout support disabled: %v", err)
+			dynamicClient = nil
+		}
+	}
+
 	controller := NewPDBController(
 		config.Interval,
 		client,
+		dynamicClient,
 		config.PDBNameSuffix,
 		config.NonReadyTTL,
 		config.ParentResourceHash,

--- a/resources.go
+++ b/resources.go
@@ -3,8 +3,18 @@ package main
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// rolloutGVR is the argoproj.io/v1alpha1 Rollout resource. Argo Rollouts is
+// optional, so it's queried via the dynamic client and a missing CRD is handled
+// gracefully (see PDBController.listRollouts).
+var rolloutGVR = schema.GroupVersionResource{
+	Group:    "argoproj.io",
+	Version:  "v1alpha1",
+	Resource: "rollouts",
+}
 
 type kubeResource interface {
 	APIVersion() string
@@ -120,4 +130,75 @@ func (d deployment) StatusReadyReplicas() int32 {
 
 func (d deployment) Selector() *metav1.LabelSelector {
 	return d.Spec.Selector
+}
+
+// argoRollout is a minimal typed projection of an argoproj.io/v1alpha1 Rollout —
+// only the fields kubeResource needs. Rollout is a Deployment-like resource, so
+// spec.replicas/selector/template and status.readyReplicas mirror the Deployment
+// shapes. It's decoded from the dynamic client's unstructured payload so the
+// controller doesn't depend on the argo-rollouts module just to read these.
+type argoRollout struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              struct {
+		Replicas *int32                `json:"replicas,omitempty"`
+		Selector *metav1.LabelSelector `json:"selector,omitempty"`
+		Template struct {
+			Metadata metav1.ObjectMeta `json:"metadata,omitempty"`
+		} `json:"template,omitempty"`
+	} `json:"spec,omitempty"`
+	Status struct {
+		ReadyReplicas int32 `json:"readyReplicas,omitempty"`
+	} `json:"status,omitempty"`
+}
+
+type rollout struct {
+	argoRollout
+}
+
+func (r rollout) APIVersion() string {
+	return r.argoRollout.APIVersion
+}
+
+func (r rollout) Kind() string {
+	return r.argoRollout.Kind
+}
+
+func (r rollout) Name() string {
+	return r.argoRollout.Name
+}
+
+func (r rollout) Namespace() string {
+	return r.argoRollout.Namespace
+}
+
+func (r rollout) UID() types.UID {
+	return r.argoRollout.UID
+}
+
+func (r rollout) Annotations() map[string]string {
+	return r.argoRollout.Annotations
+}
+
+func (r rollout) Labels() map[string]string {
+	return r.argoRollout.Labels
+}
+
+func (r rollout) TemplateLabels() map[string]string {
+	return r.Spec.Template.Metadata.Labels
+}
+
+func (r rollout) Replicas() int32 {
+	if r.Spec.Replicas == nil {
+		return 1
+	}
+	return *r.Spec.Replicas
+}
+
+func (r rollout) StatusReadyReplicas() int32 {
+	return r.Status.ReadyReplicas
+}
+
+func (r rollout) Selector() *metav1.LabelSelector {
+	return r.Spec.Selector
 }

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var rolloutGVRToListKind = map[schema.GroupVersionResource]string{
+	rolloutGVR: "RolloutList",
+}
+
+// rolloutObj builds an unstructured argoproj.io/v1alpha1 Rollout, mirroring what
+// the dynamic client returns from the API server.
+func rolloutObj(name string, replicas, ready int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Rollout",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": "default",
+		},
+		"spec": map[string]interface{}{
+			"replicas": replicas,
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": name},
+			},
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{"app": name},
+				},
+			},
+		},
+		"status": map[string]interface{}{
+			"readyReplicas": ready,
+		},
+	}}
+}
+
+func fakeDynamic(objs ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), rolloutGVRToListKind, objs...)
+}
+
+func defaultNamespace() []*v1.Namespace {
+	return []*v1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "default"}}}
+}
+
+func newController(t *testing.T, dynamicClient dynamic.Interface, deployments []*appsv1.Deployment) *PDBController {
+	t.Helper()
+	return NewPDBController(
+		0,
+		setupMockKubernetes(t, nil, deployments, nil, defaultNamespace()),
+		dynamicClient,
+		"pdb-controller",
+		0,
+		false,
+		testMaxUnavailable,
+	)
+}
+
+// A healthy multi-replica Rollout with no matching PDB gets one created, with an
+// ownerReference pointing back at the Rollout.
+func TestRolloutGetsPDB(t *testing.T) {
+	controller := newController(t, fakeDynamic(rolloutObj("rollout-x", 2, 2)), nil)
+
+	require.NoError(t, controller.runOnce(context.Background()))
+
+	pdb, err := controller.Interface.PolicyV1().PodDisruptionBudgets("default").
+		Get(context.Background(), "rollout-x-pdb-controller", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, testMaxUnavailable, *pdb.Spec.MaxUnavailable)
+	require.Equal(t, map[string]string{"app": "rollout-x"}, pdb.Spec.Selector.MatchLabels)
+	require.Len(t, pdb.OwnerReferences, 1)
+	require.Equal(t, "Rollout", pdb.OwnerReferences[0].Kind)
+	require.Equal(t, "argoproj.io/v1alpha1", pdb.OwnerReferences[0].APIVersion)
+}
+
+// A single-replica Rollout must NOT get a PDB (same rule as Deployments).
+func TestSingleReplicaRolloutGetsNoPDB(t *testing.T) {
+	controller := newController(t, fakeDynamic(rolloutObj("rollout-solo", 1, 1)), nil)
+
+	require.NoError(t, controller.runOnce(context.Background()))
+
+	_, err := controller.Interface.PolicyV1().PodDisruptionBudgets("default").
+		Get(context.Background(), "rollout-solo-pdb-controller", metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "expected no PDB for a single-replica Rollout")
+}
+
+// Supersafe: when Rollout support is disabled (nil dynamic client) the loop runs
+// normally and never touches Rollouts.
+func TestRolloutsDisabledByDefault(t *testing.T) {
+	controller := newController(t, nil, nil)
+	require.NoError(t, controller.runOnce(context.Background()))
+}
+
+// Supersafe: a missing Rollout CRD (API server returns NotFound) must not break
+// the reconcile — the Deployment still gets its PDB.
+func TestRolloutCRDMissingDoesNotBreakReconcile(t *testing.T) {
+	dynamicClient := fakeDynamic()
+	dynamicClient.PrependReactor("list", "rollouts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(rolloutGVR.GroupResource(), "")
+	})
+
+	controller := newController(t, dynamicClient, []*appsv1.Deployment{makeDeployment("deployment-x", map[string]string{"app": "deployment-x"}, 2, 2, "")})
+
+	require.NoError(t, controller.runOnce(context.Background()))
+
+	_, err := controller.Interface.PolicyV1().PodDisruptionBudgets("default").
+		Get(context.Background(), "deployment-x-pdb-controller", metav1.GetOptions{})
+	require.NoError(t, err, "Deployment PDB must still be created when the Rollout CRD is absent")
+}
+
+// Supersafe: lacking RBAC for rollouts (Forbidden) must not break the reconcile.
+func TestRolloutForbiddenDoesNotBreakReconcile(t *testing.T) {
+	dynamicClient := fakeDynamic()
+	dynamicClient.PrependReactor("list", "rollouts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(rolloutGVR.GroupResource(), "", nil)
+	})
+
+	controller := newController(t, dynamicClient, []*appsv1.Deployment{makeDeployment("deployment-x", map[string]string{"app": "deployment-x"}, 2, 2, "")})
+
+	require.NoError(t, controller.runOnce(context.Background()))
+
+	_, err := controller.Interface.PolicyV1().PodDisruptionBudgets("default").
+		Get(context.Background(), "deployment-x-pdb-controller", metav1.GetOptions{})
+	require.NoError(t, err, "Deployment PDB must still be created when rollouts RBAC is missing")
+}
+
+// Supersafe: any other (transient) list error must not break the reconcile.
+func TestRolloutGenericErrorDoesNotBreakReconcile(t *testing.T) {
+	dynamicClient := fakeDynamic()
+	dynamicClient.PrependReactor("list", "rollouts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("boom")
+	})
+
+	controller := newController(t, dynamicClient, []*appsv1.Deployment{makeDeployment("deployment-x", map[string]string{"app": "deployment-x"}, 2, 2, "")})
+
+	require.NoError(t, controller.runOnce(context.Background()))
+
+	_, err := controller.Interface.PolicyV1().PodDisruptionBudgets("default").
+		Get(context.Background(), "deployment-x-pdb-controller", metav1.GetOptions{})
+	require.NoError(t, err, "Deployment PDB must still be created when the Rollout list errors")
+}
+
+// Direct coverage of the rollout kubeResource accessors, including the
+// replicas-unset default and annotations (only otherwise hit on the
+// non-ready-ttl path).
+func TestRolloutResourceAccessors(t *testing.T) {
+	reps := int32(3)
+	r := rollout{argoRollout{
+		TypeMeta: metav1.TypeMeta{Kind: "Rollout", APIVersion: "argoproj.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "r",
+			Namespace:   "ns",
+			UID:         types.UID("uid-1"),
+			Labels:      map[string]string{"l": "1"},
+			Annotations: map[string]string{"a": "1"},
+		},
+	}}
+	r.Spec.Replicas = &reps
+	r.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "r"}}
+	r.Spec.Template.Metadata.Labels = map[string]string{"app": "r"}
+	r.Status.ReadyReplicas = 3
+
+	require.Equal(t, "argoproj.io/v1alpha1", r.APIVersion())
+	require.Equal(t, "Rollout", r.Kind())
+	require.Equal(t, "r", r.Name())
+	require.Equal(t, "ns", r.Namespace())
+	require.Equal(t, types.UID("uid-1"), r.UID())
+	require.Equal(t, map[string]string{"a": "1"}, r.Annotations())
+	require.Equal(t, map[string]string{"l": "1"}, r.Labels())
+	require.Equal(t, map[string]string{"app": "r"}, r.TemplateLabels())
+	require.Equal(t, int32(3), r.Replicas())
+	require.Equal(t, int32(3), r.StatusReadyReplicas())
+	require.Equal(t, map[string]string{"app": "r"}, r.Selector().MatchLabels)
+
+	// replicas unset defaults to 1, same as Deployments/StatefulSets
+	r.Spec.Replicas = nil
+	require.Equal(t, int32(1), r.Replicas())
+}


### PR DESCRIPTION
## What

Optionally manage default PDBs for [Argo Rollouts](https://argoproj.github.io/rollouts/) (`argoproj.io/v1alpha1`), enabled with a new `--enable-rollouts` flag.

Argo Rollouts is a Deployment-like CRD used for progressive delivery. pdb-controller doesn't know about it today, so Rollout workloads silently get no default PDB and lose voluntary-disruption protection during node drains / cluster upgrades. This adds a `rollout` `kubeResource` and feeds Rollouts through the existing PDB logic unchanged (replica/selector rules, ownerReferences, `--non-ready-ttl`).

## Design — additive and safe

This is written to be **safe to merge with no behavior change in existing code paths**:

- **Opt-in, default off.** Without `--enable-rollouts` the dynamic client is nil and behaviour is byte-for-byte identical to today — no extra API calls, no extra RBAC.
- **The flag is purely defensive / conservative.** The CRD-absent and RBAC-absent cases are handled gracefully (below), so enabling Rollout discovery is a no-op when Argo Rollouts isn't present. If you'd prefer, the flag can be **defaulted to on, or removed entirely (auto-detect), down the line** — the safe-when-absent behavior already supports that; I kept it opt-in only to guarantee zero change for existing users on first upgrade.
- **Rollout discovery can never break the existing reconcile.** `listRollouts` never returns an error:
  - CRD not installed (`NotFound` / no matching kind) → skip, debug log;
  - RBAC not granted (`Forbidden`, e.g. enabled before updating the ClusterRole) → skip, warn;
  - any other error → skip this round, error log; retried next loop.
  The CRD is re-checked every loop, so installing Argo Rollouts (or fixing RBAC) later is picked up without a restart.
- **No new module dependencies.** Rollouts are read as `unstructured` via client-go's dynamic client and decoded into a minimal typed struct, rather than importing the large `argo-rollouts` module (whose `go.mod` pulls in the AWS SDK, Prometheus, gRPC, …). `go.mod`/`go.sum` are unchanged.

## Tests

`rollout_test.go` covers: PDB creation for a healthy multi-replica Rollout (with a Rollout ownerReference), the single-replica exemption, the disabled (nil client) path, and that a **missing CRD** and **missing RBAC** do not break the reconcile (the Deployment still gets its PDB). Existing tests are unchanged apart from the new constructor arg.

Also verified end-to-end on a live cluster with real Rollouts: with `--enable-rollouts` it created a managed PDB owned by the Rollout, recreated it ~10s after deletion, and did not duplicate Rollouts already covered by a hand-written PDB; reverting the flag returned the controller to its prior behaviour.

## Docs

`docs/rbac.yaml` gains a `rollouts.argoproj.io` `get/list/watch` rule (commented as only needed with `--enable-rollouts`; harmless when the CRD is absent), and the README documents the flag.